### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prod-website-deployment.yml
+++ b/.github/workflows/prod-website-deployment.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: read
       pages: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/prod-website-deployment.yml
+++ b/.github/workflows/prod-website-deployment.yml
@@ -14,6 +14,9 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
+    permissions:
+      contents: read
+      pages: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,6 +40,8 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
+    permissions:
+      contents: read
     steps:
       - name: Close Pull Request
         id: closepullrequest


### PR DESCRIPTION
Potential fix for [https://github.com/MattWhite-personal/matthewjwhite.co.uk/security/code-scanning/5](https://github.com/MattWhite-personal/matthewjwhite.co.uk/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimal permissions required for each job. For the `build_and_deploy_job`, we will grant `contents: read` and `pages: write` permissions, as it involves deploying content. For the `close_pull_request_job`, we will grant only `contents: read` permissions, as it does not require write access.

The `permissions` block will be added at the job level to ensure each job has the least privileges necessary for its specific tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
