### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   format-code:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -5,7 +5,8 @@ on:
     types: [opened, edited, reopened, synchronize]
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   format-code:


### PR DESCRIPTION
Potential fix for [https://github.com/MattWhite-personal/matthewjwhite.co.uk/security/code-scanning/1](https://github.com/MattWhite-personal/matthewjwhite.co.uk/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it appears that the workflow primarily interacts with the repository's contents and does not require write access. Therefore, we will set `contents: read` as the permission. If additional permissions are required in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
